### PR TITLE
Update separation_by_localization.py to support inference on CPU

### DIFF
--- a/cos/inference/separation_by_localization.py
+++ b/cos/inference/separation_by_localization.py
@@ -191,7 +191,7 @@ def main(args):
 
     args.device = device
     model = CoSNetwork(n_audio_channels=args.n_channels)
-    model.load_state_dict(torch.load(args.model_checkpoint), strict=True)
+    model.load_state_dict(torch.load(args.model_checkpoint), strict=True, map_location=args.device)
     model.train = False
     model.to(device)
 


### PR DESCRIPTION
Loading the current model without GPU doesn't work, since torch still tries to load the model on GPU. This fixes it.